### PR TITLE
Prevent link properties from warning on nil

### DIFF
--- a/lib/bridgetown/webfinger/properties.rb
+++ b/lib/bridgetown/webfinger/properties.rb
@@ -17,6 +17,8 @@ module Bridgetown
       # @param data [Hash] the data to parse as a properties object
       # @return [Properties, nil] the properties parsed from the data
       def self.parse(data)
+        return unless data
+
         unless data.is_a?(Hash)
           return warn("Webfinger link properties are malformed: #{data.inspect}, ignoring")
         end

--- a/test/bridgetown/webfinger/link_test.rb
+++ b/test/bridgetown/webfinger/link_test.rb
@@ -35,6 +35,20 @@ module Bridgetown
         assert_match %r{rel is missing}, output
       end
 
+      def test_link_without_properties
+        output = with_log_output do
+          link = link(
+            href: "https://example.com/",
+            rel: "http://webfinger.net/rel/profile-page",
+            type: "text/html"
+          )
+
+          assert_nil link.properties
+        end
+
+        refute_match %r{Webfinger link properties}, output
+      end
+
       def test_pruning_malformed_properties
         output = with_log_output do
           link = link(


### PR DESCRIPTION
This isn't invalid, it's a perfectly reasonable way to do things. In particular because the LRD ecosystem hasn't developed outside of Solid, most people don't use properties.

As such, we should not warn when properties are missing.