### PR TITLE
Prepare for the 0.1.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
       - "*"
 
 jobs:
+  docs:
+    runs-on: ubuntu-latest
+    name: Lint Ruby files
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+      - uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-${{ matrix.ruby }}-
+      - name: Run Inch
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle check || bundle install --jobs 4 --retry 3
+          bundle exec inch suggest
+
   lint:
     runs-on: ubuntu-latest
     name: Lint Ruby files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
           gem install bundler
           bundle config path vendor/bundle
           bundle check || bundle install --jobs 4 --retry 3
-          bundle exec rake test:all
+          bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 gem "bridgetown", ENV["BRIDGETOWN_VERSION"] if ENV["BRIDGETOWN_VERSION"]
 
 group :development do
+  gem "inch"
   gem "pry"
   gem "pry-byebug"
   gem "rackup" # for yard server; https://github.com/lsegal/yard/issues/1473

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,11 @@ GEM
       activesupport (>= 5.0.0, < 8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    inch (0.8.0)
+      pry
+      sparkr (>= 0.2.0)
+      term-ansicolor
+      yard (~> 0.9.12)
     json (2.6.3)
     kramdown (2.4.0)
       rexml
@@ -160,12 +165,18 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sparkr (0.4.1)
     standard (1.22.1)
       language_server-protocol (~> 3.17.0.2)
       rubocop (= 1.42.0)
       rubocop-performance (= 1.15.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
     thor (1.2.1)
     tilt (2.0.11)
+    tins (1.32.1)
+      sync
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
@@ -182,6 +193,7 @@ PLATFORMS
 DEPENDENCIES
   bridgetown-webfinger!
   bundler (>= 2)
+  inch
   minitest
   minitest-reporters
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ PLATFORMS
 
 DEPENDENCIES
   bridgetown-webfinger!
-  bundler (>= 1.16)
+  bundler (>= 2)
   minitest
   minitest-reporters
   pry

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin allows for hosting Webfinger lookups on your website for [`acct:` UR
 [1]: https://www.bridgetownrb.com
 [2]: https://webfinger.net/
 [3]: https://indieweb.org/
-[4]: https://datatracker.ietf.org/doc/html/rfc2396
+[4]: https://datatracker.ietf.org/doc/html/rfc7565
 [5]: https://joinmastodon.org/
 [6]: https://pleroma.social/
 [7]: https://joinpeertube.org/

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "bundler/gem_tasks"
+require "inch/rake"
 require "rake/testtask"
 require "standard/rake"
 
@@ -28,6 +29,8 @@ task :test do
   Rake::Task["test:all"].invoke
 end
 
+Inch::Rake::Suggest.new(:inch)
+
 namespace :data do
   desc "Pull the list of current registered link relations from the IANA database"
   task :link_relations do
@@ -42,4 +45,4 @@ namespace :data do
   end
 end
 
-task default: ["test", "standard:fix"]
+task default: ["test", "standard:fix", "inch"]

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,13 @@ namespace :test do
   end
 end
 
+task :test do
+  require "fileutils"
+  FileUtils.remove_entry("coverage", true)
+  ENV["COVERAGE"] = "1"
+  Rake::Task["test:all"].invoke
+end
+
 namespace :data do
   desc "Pull the list of current registered link relations from the IANA database"
   task :link_relations do
@@ -35,4 +42,4 @@ namespace :data do
   end
 end
 
-task default: ["test:all", "standard:fix"]
+task default: ["test", "standard:fix"]

--- a/bridgetown-webfinger.gemspec
+++ b/bridgetown-webfinger.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |spec|
   spec.files += Dir["lib/**/*.rb"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency "bridgetown", ">= 1.2", "< 2.0"
   spec.add_dependency "uri", ">= 0.12.0"
   spec.add_dependency "zeitwerk"
 
-  spec.add_development_dependency "bundler", ">= 1.16"
+  spec.add_development_dependency "bundler", ">= 2"
 end

--- a/bridgetown-webfinger.gemspec
+++ b/bridgetown-webfinger.gemspec
@@ -23,4 +23,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "zeitwerk"
 
   spec.add_development_dependency "bundler", ">= 2"
+
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/michaelherold/bridgetown-webfinger/issues",
+    "changelog_uri" => "https://github.com/michaelherold/bridgetown-webfinger/blob/main/CHANGELOG.md",
+    "documentation_uri" => "https://rubydoc.info/gems/bridgetown-webfinger/#{Bridgetown::Webfinger::VERSION}",
+    "homepage_uri" => "https://github.com/michaelherold/bridgetown-webfinger",
+    "rubygems_mfa_required" => "true",
+    "source_code_uri" => "https://github.com/michaelherold/bridgetown-webfinger"
+  }
 end

--- a/test/bridgetown/webfinger/properties_test.rb
+++ b/test/bridgetown/webfinger/properties_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Bridgetown
+  module Webfinger
+    class PropertiesTest < Minitest::Test
+      def test_a_fully_appropriate_example
+        properties = Properties.parse(
+          {"http://packetizer.com/ns/name" => "Bilbo Baggins"}
+        )
+
+        assert_equal "Bilbo Baggins", properties["http://packetizer.com/ns/name"]
+      end
+
+      def test_parsing_nil
+        assert_nil Properties.parse(nil)
+      end
+
+      def test_pruning_malformed_properties
+        output = with_log_output do
+          properties = Properties.parse(1_234)
+
+          assert_nil properties
+        end
+
+        assert_match %r{Webfinger link properties are malformed}, output
+      end
+
+      private
+
+      def with_log_output
+        original_logger = Bridgetown.logger
+        output = StringIO.new
+        Bridgetown.instance_variable_set(
+          :@logger,
+          Bridgetown::LogAdapter.new(
+            Bridgetown::LogWriter.new.tap do |writer|
+              writer.define_singleton_method(:logdevice) { |_| output }
+            end,
+            :debug
+          )
+        )
+        yield if block_given?
+        output.string
+      ensure
+        Bridgetown.instance_variable_set(:@logger, original_logger)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a random collection of polish items for preparing for the first public release:

1. Update the proper expectation for Ruby and Bundler versions, 3.0+ and 2.0+, respectively.
2. Add gem metadata for showing links on RubyGems.org
3. Update the Rakefile to have a `test` task that does what the contributing guidelines say it does
4. Adjust the default Rake task to check documentation coverage, per the contributing guidelines and start checking it in CI
5. Add a missing test
6. Adjust a link in the readme to the correct place